### PR TITLE
updated apiVersion for Route

### DIFF
--- a/apache_login_proxy.yaml
+++ b/apache_login_proxy.yaml
@@ -68,7 +68,7 @@ spec:
 
 ---
 
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:


### PR DESCRIPTION
route.openshift.io/v1 is required for 4.11